### PR TITLE
feat: add widget source as fak prefix for localStorage

### DIFF
--- a/src/lib/data/near.js
+++ b/src/lib/data/near.js
@@ -560,11 +560,11 @@ async function _initNear({
 
 
   _near.requestFak = (contractName, methodNames) => requestFak("slackApp", _near, contractName, methodNames);
-  _near.requestCalimeroFak = (contractName, methodNames) => requestCalimeroFak("slackApp", _near, contractName, methodNames);
+  _near.requestCalimeroFak = (componentName, contractName, methodNames) => requestCalimeroFak(componentName, _near, contractName, methodNames);
   _near.submitFakTransaction = (contractName, methodName, args, gas, deposit) => submitFakTransaction("slackApp", _near, contractName, methodName, args, gas, deposit);
-  _near.submitCalimeroFakTransaction = (contractName, methodName, args, gas, deposit) => submitFakCalimeroTransaction("slackApp", _near, contractName, methodName, args, gas, deposit);
+  _near.submitCalimeroFakTransaction = (componentName, contractName, methodName, args, gas, deposit) => submitFakCalimeroTransaction(componentName, _near, contractName, methodName, args, gas, deposit);
   _near.verifyFak = (contractName, methodNames) => verifyFak("slackApp", _near, contractName, methodNames);
-  _near.verifyCalimeroFak = (contractName, methodNames) => verifyCalimeroFak("slackApp", _near, contractName, methodNames);
+  _near.verifyCalimeroFak = (componentName, contractName, methodNames) => verifyCalimeroFak(componentName, _near, contractName, methodNames);
   _near.block = (blockHeightOrFinality) => {
     const blockQuery = transformBlockId(blockHeightOrFinality);
     const provider = blockQuery.blockId

--- a/src/lib/vm/vm.js
+++ b/src/lib/vm/vm.js
@@ -831,9 +831,9 @@ class VmStack {
       } else if (keyword === "Near" && callee === "requestFak") {
         return this.vm.near.requestFak(...args);
       } else if (keyword === "Near" && callee === "requestCalimeroFak") {
-        return this.vm.near.requestCalimeroFak(...args);
+        return this.vm.near.requestCalimeroFak(this.vm.widgetSrc, ...args);
       } else if (keyword === "Near" && callee === "hasValidCalimeroFak") {
-        return this.vm.near.verifyCalimeroFak(...args);
+        return this.vm.near.verifyCalimeroFak(this.vm.widgetSrc, ...args);
       } else if (keyword === "Near" && callee === "hasValidFak") {
         return this.vm.near.verifyFak(...args);
       } else if (keyword === "Near" && callee === "fakCalimeroCall") {
@@ -843,6 +843,7 @@ class VmStack {
           );
         }
         return this.vm.near.submitCalimeroFakTransaction(
+          this.vm.widgetSrc,
           args[0],
           args[1],
           args[2] ?? {},


### PR DESCRIPTION
## feat: add widget source as fak prefix for localStorage
When user is using calimero Functions, the keys are stored in localStorage with predefined prefix. Before it was hardcoded as "SlackApp" and now it takes the name of the widget source ("accountID/widget/ComponentName") to get unique prefix for saved functionkeys.
