### PR TITLE
feat(VM): add Promise support

### DIFF
--- a/src/lib/vm/vm.js
+++ b/src/lib/vm/vm.js
@@ -254,6 +254,7 @@ const Keywords = {
   VM: true,
   Calimero: true,
   Crypto: true,
+  Promise,
 };
 
 const ReservedKeys = {
@@ -1157,6 +1158,13 @@ class VmStack {
       ) {
         const keyword = code.object.name;
         if (keyword in Keywords) {
+          // Special case for Promise.all and Promise.any
+          if (keyword === 'Promise' && ['all', 'any'].includes(code.property.name)) {
+            return {
+              obj: Promise,  // Return the Promise object itself
+              key: code.property.name
+            };
+           }
           if (!options?.callee) {
             throw new Error(
               "Cannot dereference keyword '" +


### PR DESCRIPTION
* Base VM doesn't allow to use Promises in the code, what is a limitation to create more advance generators which can be use with useCache hook.
* This PR enable the creation of Promises using standard new Promise + static methods Promise.all and Promise.any