### PR TITLE
feat: useRef naive implementation

### DIFF
--- a/src/lib/vm/vm.js
+++ b/src/lib/vm/vm.js
@@ -1203,7 +1203,21 @@ class VmStack {
               dependencies,
           });
           return memoized;
-      } else if (callee === "setTimeout") {
+        } else if (callee === "useRef") {
+          if (this.prevStack) {
+            throw new Error(
+              'useRef hook error: Hooks should only be called from the top level, not inside loops, conditions, or nested functions.'
+            );
+          }
+          const hookIndex = this.hookIndex++;
+          if (!this.vm.hooks[hookIndex]) {
+            const initialValue = args.length > 0 ? args[0] : null;
+            const newRef = { current: initialValue };
+            this.vm.setReactHook(hookIndex, { ref: newRef });
+            return newRef;
+          }
+          return this.vm.hooks[hookIndex].ref;
+        } else if (callee === "setTimeout") {
           const [callback, timeout] = args;
           const timer = setTimeout(() => {
             if (!this.vm.alive) {


### PR DESCRIPTION
This PR introduces custom handling for the React useRef hook within our framework. The primary aim is to ensure hooks are called from the top-level and to manage the storage and retrieval of hooks.

* Check if the useRef is called from the top of the stack.
* Handle the creation or retrieval of hook references based on the current hook index.