### PR TITLE
feat: add `Calimero.fakSignTx` method

### DIFF
--- a/src/lib/vm/vm.js
+++ b/src/lib/vm/vm.js
@@ -901,6 +901,21 @@ class VmStack {
           args[3],
           args[4]
         );
+      } else if (keyword === "Calimero" && callee === "fakSignTx") {
+        if (args.length < 2 || args.length > 5) {
+          throw new Error(
+            "Method: Calimero.fakSignTx. Required argument: 'contractName'. If the first argument is a string: 'methodName'. Optional: 'args', 'gas' (defaults to 300Tg), 'deposit' (defaults to 0)"
+          );
+        }
+
+        return this.vm.near.signCalimeroFakTransaction(
+          this.vm.near.calimeroConnection.config.networkId,
+          args[0],
+          args[1],
+          args[2] ?? {},
+          args[3],
+          args[4]
+        );
       } else if (keyword === "Calimero" && callee === "sign") {
         if (args.length !== 2) {
           throw new Error(


### PR DESCRIPTION
Adds a new method exposed to the VM.

`Calimero.fakSignTx(contract, method, args?, gas?, deposit?)`

- `contract`: `String` The receiver of this transaction.
- `method`: `String` The method being called. 
- `args`?: `Object` The arguments being passed.
- `gas`?: `Number` The attached gas for this transaction.
- `deposit`?: `Number` Attached deposit, if any.

Returns: `[Base58TxHash, Base64SignedTx]`

Signs a NEAR transaction with the Calimero Full Access Key, and returns the base58-encoded transaction hash and the base64-encoded, borsh-compacted `SignedTransaction`.