### PR TITLE
fix(VM): set default gas for signCalimeroTx

### DIFF
--- a/src/lib/data/near.js
+++ b/src/lib/data/near.js
@@ -293,7 +293,7 @@ async function signCalimeroFakTransaction(storageKey, near, contractName, method
         nearAPI.transactions.functionCall(
           methodName,
           args,
-          gas ?? TGas.mul(30).toFixed(0),
+          gas ?? TGas.mul(300).toFixed(0),
           deposit ?? "0"
         )
       ]

--- a/src/lib/data/near.js
+++ b/src/lib/data/near.js
@@ -292,9 +292,9 @@ async function signCalimeroFakTransaction(storageKey, near, contractName, method
       contractName, [
         nearAPI.transactions.functionCall(
           methodName,
-          {...args},
-          gas?.toFixed(0),
-          deposit?.toFixed(0)
+          args,
+          gas ?? TGas.mul(30).toFixed(0),
+          deposit ?? "0"
         )
       ]
     );


### PR DESCRIPTION
Sending txs signed with default values in the relayer were failing. After making meroship calls synchronous I was able to see the response from the rpc. 
```
  "error": {
    "cause": {
      "info": {},
      "name": "INVALID_TRANSACTION"
    },
    "code": -32000,
    "data": {
      "TxExecutionError": {
        "InvalidTxError": {
          "ActionsValidation": "FunctionCallZeroAttachedGas"
        }
      }
    },
    "message": "Server error",
    "name": "HANDLER_ERROR"
  },
  "id": "NDSzGiXhY",
  "jsonrpc": "2.0"
}   
```

With this change I was able to send the firsts messages using through a websocket:
<img width="1792" alt="Screen Shot 2023-10-06 at 10 00 45 PM" src="https://github.com/NearSocial/VM/assets/2929173/4f56a578-548d-4aef-a7d8-afb62dbd0942">
