### PR TITLE
feat: add sandbox options

### DIFF
--- a/src/lib/components/SecureIframe.js
+++ b/src/lib/components/SecureIframe.js
@@ -21,7 +21,7 @@ export default function SecureIframe(allProps) {
   const [loaded, setLoaded] = useState(false);
   const [prevMessage, setPrevMessage] = useState(undefined);
   const ref = React.useRef();
-  const sandbox = "allow-scripts";
+  const sandbox = "allow-scripts allow-popups allow-popups-to-escape-sandbox";
 
   const returnIframeResizerProps = () => {
     const result = {


### PR DESCRIPTION
# feat: add sandbox options

## Summary:
Adding this options makes url links in chat clickable and they will open in a new tab. The reason for this is because our message text gets parsed to markdown and then is added to iframe which makes it a iframe sandbox. Withouth this urls would render the url pages inside the iframe in chat.

Fixes [AM-1944](https://calimero.atlassian.net/browse/AM-1944)

## Tests:

https://github.com/calimero-is-near/VM/assets/93442516/74dafef0-90c3-49af-bc58-d44d2c56723a


