### PR TITLE
feature: input field max height

### DIFF
--- a/src/lib/components/md-editor.css
+++ b/src/lib/components/md-editor.css
@@ -14,7 +14,7 @@
   max-height: 456px;
   overflow-y: scroll;
   @media (max-width: 1024px) {
-    max-height: 84px;
+    max-height: 155px;
   }
 }
 p {

--- a/src/lib/components/md-editor.css
+++ b/src/lib/components/md-editor.css
@@ -11,6 +11,11 @@
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
   background-color: #0e0e10;
+  max-height: 456px;
+  overflow-y: scroll;
+  @media (max-width: 1024px) {
+    max-height: 84px;
+  }
 }
 p {
   height: auto;


### PR DESCRIPTION
# feature: input field max height

## Summary:
Added max height value for desktop 456px (as on figma) and 84px for mobile (also from figma).

Fixes: [AM-1948](https://calimero.atlassian.net/browse/AM-1948)

## Tests:

https://github.com/calimero-is-near/VM/assets/93442516/233b1004-494e-44d8-976e-8eec1fc42b3c

