### PR TITLE
feat: extract and clean url params

### DIFF
--- a/src/lib/vm/vm.js
+++ b/src/lib/vm/vm.js
@@ -1344,6 +1344,16 @@ class VmStack {
             return newRef;
           }
           return this.vm.hooks[hookIndex].ref;
+        } else if (callee === "extractQueryParams") {
+          const currentURL = new URL(window.location.href);
+          const params = new URLSearchParams(currentURL.search);
+          const paramsObject = {};
+          for (const [key, value] of params.entries()) {
+            paramsObject[key] = value;
+          }
+          currentURL.search = "";
+          history.pushState({}, "", currentURL.toString());
+          return paramsObject; 
         } else if (callee === "setTimeout") {
           const [callback, timeout] = args;
           const timer = setTimeout(() => {


### PR DESCRIPTION
Added a new fuction method which extract the url query params, pass them as an object and updates the url without reloading it

Test URL http://localhost:3000/xabi-staging.testnet/widget/UrlParamsExtractor.jsx?param1=hello&param2=world

https://github.com/calimero-is-near/VM/assets/2929173/15df6243-4411-4528-89c4-0eedb8fd93c3

