### PR TITLE
fix: purify pasted html to markdown editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "remark-gfm": "^3.0.1",
     "styled-components": "^5.3.6",
     "tweetnacl": "^1.0.3",
-    "virtualized-chat": "0.0.0-alpha.35"
+    "virtualized-chat": "0.0.0-alpha.36"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/src/lib/components/MarkdownEditor.js
+++ b/src/lib/components/MarkdownEditor.js
@@ -29,8 +29,8 @@ export const MarkdownEditor = (props) => {
       theme="snow"
       value={props.value}
       onChange={(value) => {
-        const newVal = sanitizePasteHtml(value);
-        props.setValue(newVal);
+        const purifiedText = sanitizePasteHtml(value);
+        props.setValue(purifiedText);
       }}
       onKeyDown={(e) => {
         if (e.key === "Enter" && !e.shiftKey) {

--- a/src/lib/components/MarkdownEditor.js
+++ b/src/lib/components/MarkdownEditor.js
@@ -1,6 +1,7 @@
 import "./quill.snow.css";
 import React, { useEffect } from "react";
 import ReactQuill from "react-quill";
+import { sanitizePasteHtml } from "virtualized-chat";
 
 export const MarkdownEditor = (props) => {
   useEffect(() => {
@@ -27,7 +28,10 @@ export const MarkdownEditor = (props) => {
       }}
       theme="snow"
       value={props.value}
-      onChange={props.setValue}
+      onChange={(value) => {
+        const newVal = sanitizePasteHtml(value);
+        props.setValue(newVal);
+      }}
       onKeyDown={(e) => {
         if (e.key === "Enter" && !e.shiftKey) {
           props.handleMessageSent();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10066,10 +10066,10 @@ vfile@^5.0.0:
     unist-util-stringify-position "^3.0.0"
     vfile-message "^3.0.0"
 
-virtualized-chat@0.0.0-alpha.35:
-  version "0.0.0-alpha.35"
-  resolved "https://registry.yarnpkg.com/virtualized-chat/-/virtualized-chat-0.0.0-alpha.35.tgz#819f9deb514af15696a073c9258700462be541c0"
-  integrity sha512-hfNKMdLYrrhlMZkPOId7WDextonAIYUUiOojVoP5u+jko5Ofmq0ykImMvEzxzjdSG5qyvg700uTYhu0PnIOVGQ==
+virtualized-chat@0.0.0-alpha.36:
+  version "0.0.0-alpha.36"
+  resolved "https://registry.yarnpkg.com/virtualized-chat/-/virtualized-chat-0.0.0-alpha.36.tgz#c3d259b0a0b8d202e9c9e372197eab0be5ac85de"
+  integrity sha512-YJ11pixBqqjLbcHmaPjD5ZHEkZUTIcYEtHXjnPWrRY+3enZHIOzZVJMgLhhCmOuo1lbTo4o1gVZ9vt3ffd2iFw==
   dependencies:
     "@radix-ui/react-dialog" "^1.0.5"
     "@uidotdev/usehooks" "^2.4.1"


### PR DESCRIPTION
# fix: purify pasted html to markdown editor 

* will be merged after virtualized chat goes to v36 and vm package.json also updated
## Summary:
Explained [here](https://github.com/calimero-is-near/virtualized-chat/pull/38)

fixes: [AM-2012]

Tests

Uploading Screen Recording 2023-10-31 at 20.16.36.mov…

