### PR TITLE
fix(bos-gateway): Revert virtualized-chat back to alpha50

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "stream-browserify": "^3.0.0",
     "styled-components": "^5.3.6",
     "tweetnacl": "^1.0.3",
-    "virtualized-chat": "0.0.0-alpha.53"
+    "virtualized-chat": "0.0.0-alpha.50"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",


### PR DESCRIPTION
This is the last version with which a successful build on argo passes for calimero bos-gateway